### PR TITLE
feat: protected tags file per subset UI

### DIFF
--- a/main_ui_files/SubsetUI.py
+++ b/main_ui_files/SubsetUI.py
@@ -57,10 +57,10 @@ class SubsetWidget(BaseWidget):
         self.widget.masked_image_selector.setIcon(
             QIcon(str(Path("icons/more-horizontal.svg")))
         )
-        self.widget.protected_tags_input.setMode("file", [".txt"])
-        self.widget.protected_tags_input.highlight = True
-        self.widget.protected_tags_input.allow_empty = True
-        self.widget.protected_tags_selector.setIcon(
+        self.extra_widget.protected_tags_input.setMode("file", [".txt"])
+        self.extra_widget.protected_tags_input.highlight = True
+        self.extra_widget.protected_tags_input.allow_empty = True
+        self.extra_widget.protected_tags_selector.setIcon(
             QIcon(str(Path("icons/more-horizontal.svg")))
         )
 
@@ -159,12 +159,12 @@ class SubsetWidget(BaseWidget):
         self.extra_widget.token_warmup_step_input.valueChanged.connect(
             lambda x: self.edit_dataset_args("token_warmup_step", x)
         )
-        self.widget.protected_tags_input.textChanged.connect(
+        self.extra_widget.protected_tags_input.textChanged.connect(
             lambda x: self.edit_dataset_args("protected_tags_file", x, True)
         )
-        self.widget.protected_tags_selector.clicked.connect(
+        self.extra_widget.protected_tags_selector.clicked.connect(
             lambda: self.set_file_from_dialog(
-                "Protected Tags File", self.widget.protected_tags_input
+                "Protected Tags File", self.extra_widget.protected_tags_input
             )
         )
 
@@ -413,7 +413,7 @@ class SubsetWidget(BaseWidget):
         self.extra_widget.token_warmup_step_input.setValue(
             dataset_args.get("token_warmup_step", 1)
         )
-        self.widget.protected_tags_input.setText(
+        self.extra_widget.protected_tags_input.setText(
             dataset_args.get("protected_tags_file", "")
         )
 
@@ -464,7 +464,7 @@ class SubsetWidget(BaseWidget):
             self.extra_widget.shuffle_caption_group.isChecked()
         )
         self.edit_dataset_args(
-            "protected_tags_file", self.widget.protected_tags_input. text(), True
+            "protected_tags_file", self.extra_widget.protected_tags_input.text(), True
         )
 
         self.edited.emit(self.dataset_args, self.name)

--- a/ui_files/sub_dataset_extra_input.py
+++ b/ui_files/sub_dataset_extra_input.py
@@ -16,9 +16,10 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QImage, QKeySequence, QLinearGradient, QPainter,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QAbstractSpinBox, QApplication, QFormLayout, QGroupBox,
-    QLabel, QSizePolicy, QVBoxLayout, QWidget)
+        QLabel, QSizePolicy, QVBoxLayout, QWidget, QGridLayout, QPushButton)
 
 from modules.ScrollOnSelect import (DoubleSpinBox, SpinBox)
+from modules.DragDropLineEdit import DragDropLineEdit
 
 class Ui_sub_dataset_extra_input(object):
     def setupUi(self, sub_dataset_extra_input):
@@ -142,6 +143,29 @@ class Ui_sub_dataset_extra_input(object):
 
         self.formLayout.setWidget(2, QFormLayout.FieldRole, self.caption_tag_dropout_input)
 
+        self.protected_tags_label = QLabel(self.caption_dropout_group)
+        self.protected_tags_label.setObjectName(u"protected_tags_label")
+        self.protected_tags_label.setEnabled(True)
+
+        self.formLayout.setWidget(3, QFormLayout.LabelRole, self.protected_tags_label)
+
+        self.protected_tags_grid = QGridLayout()
+        self.protected_tags_grid.setObjectName(u"protected_tags_grid")
+        self.protected_tags_grid.setHorizontalSpacing(8)
+        self.protected_tags_input = DragDropLineEdit(self.caption_dropout_group)
+        self.protected_tags_input.setObjectName(u"protected_tags_input")
+        self.protected_tags_input.setEnabled(True)
+
+        self.protected_tags_grid.addWidget(self.protected_tags_input, 0, 0, 1, 1)
+
+        self.protected_tags_selector = QPushButton(self.caption_dropout_group)
+        self.protected_tags_selector.setObjectName(u"protected_tags_selector")
+        self.protected_tags_selector.setEnabled(True)
+
+        self.protected_tags_grid.addWidget(self.protected_tags_selector, 0, 1, 1, 1)
+
+        self.formLayout.setLayout(3, QFormLayout.FieldRole, self.protected_tags_grid)
+
 
         self.verticalLayout.addWidget(self.caption_dropout_group)
 
@@ -245,6 +269,18 @@ class Ui_sub_dataset_extra_input(object):
 #if QT_CONFIG(tooltip)
         self.caption_tag_dropout_input.setToolTip(QCoreApplication.translate("sub_dataset_extra_input", u"<html><head/><body><p>The default rate that any one caption tag gets dropped.</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
+#if QT_CONFIG(tooltip)
+        self.protected_tags_label.setToolTip(QCoreApplication.translate("sub_dataset_extra_input", u"<html><head/><body><p>'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.protected_tags_label.setText(QCoreApplication.translate("sub_dataset_extra_input", u"Protected Tags File", None))
+#if QT_CONFIG(tooltip)
+        self.protected_tags_input.setToolTip(QCoreApplication.translate("sub_dataset_extra_input", u"<html><head/><body><p>'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.protected_tags_input.setPlaceholderText(QCoreApplication.translate("sub_dataset_extra_input", u"Protected Tags File", None))
+#if QT_CONFIG(tooltip)
+        self.protected_tags_selector.setToolTip(QCoreApplication.translate("sub_dataset_extra_input", u"<html><head/><body><p>'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting.</p></body></html>", None))
+#endif // QT_CONFIG(tooltip)
+        self.protected_tags_selector.setText("")
 #if QT_CONFIG(tooltip)
         self.token_warmup_group.setToolTip(QCoreApplication.translate("sub_dataset_extra_input", u"<html><head/><body><p>Token Warmup is a way to add tokens into the training data as the training continues</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)

--- a/ui_files/sub_dataset_extra_input.ui
+++ b/ui_files/sub_dataset_extra_input.ui
@@ -264,6 +264,52 @@
         </property>
        </widget>
       </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="protected_tags_label">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="text">
+       <string>Protected Tags File</string>
+      </property>
+      <property name="toolTip">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <layout class="QGridLayout" name="protected_tags_grid">
+      <property name="horizontalSpacing">
+       <number>8</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="DragDropLineEdit" name="protected_tags_input">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="placeholderText">
+         <string>Protected Tags File</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="protected_tags_selector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
      </layout>
     </widget>
    </item>

--- a/ui_files/sub_dataset_input.py
+++ b/ui_files/sub_dataset_input.py
@@ -203,27 +203,6 @@ class Ui_sub_dataset_input(object):
 
         self.gridLayout.addLayout(self.gridLayout_3, 2, 0, 1, 2)
 
-        self.protected_tags_grid = QGridLayout()
-        self.protected_tags_grid.setObjectName("protected_tags_grid")
-        self.protected_tags_grid.setHorizontalSpacing(8)
-        self.protected_tags_input = DragDropLineEdit(sub_dataset_input)
-        self.protected_tags_input.setObjectName("protected_tags_input")
-        self.protected_tags_input.setEnabled(True)
-
-        self.protected_tags_grid.addWidget(self.protected_tags_input, 1, 0, 1, 1)
-
-        self.protected_tags_selector = QPushButton(sub_dataset_input)
-        self.protected_tags_selector.setObjectName("protected_tags_selector")
-        self.protected_tags_selector.setEnabled(True)
-
-        self.protected_tags_grid.addWidget(self.protected_tags_selector, 1, 1, 1, 1)
-
-        self.protected_tags_label = QLabel(sub_dataset_input)
-        self.protected_tags_label.setObjectName("protected_tags_label")
-
-        self.protected_tags_grid.addWidget(self.protected_tags_label, 0, 0, 1, 2)
-
-        self.gridLayout.addLayout(self.protected_tags_grid, 3, 0, 1, 2)
 
         self.retranslateUi(sub_dataset_input)
 
@@ -312,40 +291,4 @@ class Ui_sub_dataset_input(object):
         self.label.setToolTip(QCoreApplication.translate("sub_dataset_input", u"<html><head/><body><p>Masked Image Dir is only used when masked loss is checked. This is where the masks for the images in the given folder are to be provided</p></body></html>", None))
 #endif // QT_CONFIG(tooltip)
         self.label.setText(QCoreApplication.translate("sub_dataset_input", u"Masked Image Dir", None))
-        self.protected_tags_grid.setObjectName(
-            QCoreApplication.translate("sub_dataset_input", "protected_tags_grid", None)
-        )
-        # if QT_CONFIG(tooltip)
-        self.protected_tags_input.setToolTip(
-            QCoreApplication.translate(
-                "sub_dataset_input",
-                "<html><head/><body><p>'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting. </p></body></html>",
-                None,
-            )
-        )
-        # endif // QT_CONFIG(tooltip)
-        self.protected_tags_input.setPlaceholderText(
-            QCoreApplication.translate("sub_dataset_input", "Protected Tags File", None)
-        )
-        # if QT_CONFIG(tooltip)
-        self.protected_tags_selector.setToolTip(
-            QCoreApplication.translate(
-                "sub_dataset_input",
-                "<html><head/><body><p>'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting. </p></body></html>",
-                None,
-            )
-        )
-        # endif // QT_CONFIG(tooltip)
-        self.protected_tags_selector.setText("")
-        # if QT_CONFIG(tooltip)
-        self.protected_tags_label.setToolTip(
-            QCoreApplication.translate(
-                "sub_dataset_input",
-                "<html><head/><body><p>'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting. </p></body></html>",
-                None,
-            )
-        )
-        # endif // QT_CONFIG(tooltip)
-        self.protected_tags_label.setText(QCoreApplication.translate("sub_dataset_input", "Protected Tags File", None))
-
     # retranslateUi

--- a/ui_files/sub_dataset_input.ui
+++ b/ui_files/sub_dataset_input.ui
@@ -255,55 +255,6 @@
      </item>
     </layout>
     </item>
-    <item row="3" column="0" colspan="2">
-
-    <layout class="QGridLayout" name="protected_tags_grid">
-        <property name="objectName">
-        <string>protected_tags_grid</string>
-        </property>
-        <property name="horizontalSpacing">
-        <number>8</number>
-        </property>
-        <item row="1" column="0">
-        <widget class="DragDropLineEdit" name="protected_tags_input">
-        <property name="enabled">
-            <bool>true</bool>
-        </property>
-        <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="placeholderText">
-            <string>Protected Tags File</string>
-        </property>
-        </widget>
-        </item>
-        <item row="1" column="1">
-        <widget class="QPushButton" name="protected_tags_selector">
-        <property name="enabled">
-            <bool>true</bool>
-        </property>
-        <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;F'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-            <string/>
-        </property>
-        </widget>
-        </item>
-        <item row="0" column="0" colspan="2">
-        <widget class="QLabel" name="protected_tags_label">
-        <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;'.txt' file containing tags to protect from caption tag dropout (one tag per line). Similar to 'Keep Tokens' except that protected tags work with shuffle captions to allow less stiff prompting. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-            <string>Protected Tags File</string>
-        </property>
-        </widget>
-        </item>
-        </layout>
-
-   </item>
-  </layout>
  </widget>
  <customwidgets>
   <customwidget>


### PR DESCRIPTION
Adds a protected tags textbox and file dialogue button to dataset subsets UI to allow applying protected tags file on a per-subset through the UI.

Currently it goes below "Masked Image Dir" though since protected tags don't do anything without tag caption dropout enabled I'll probably move it into the optional args checkbox grid later.  

<img width="813" height="640" alt="image" src="https://github.com/user-attachments/assets/2c6dcb3d-9c09-4b5a-aaf1-4e4541aebe3c" />

This PR requires a backend change to protected tags and subset arg parsing in sd-scripts (hopefully correctly) implemented by https://github.com/67372a/sd-scripts/pull/224

The PR is currently a draft mainly to allow testing, until I move the UI element into the caption dropout part

As an extra note, while I did change the .ui file, it has no use since it's out of sync with the uic generated python code