### PR TITLE
Adjustments to Extra Args UI

### DIFF
--- a/main_ui_files/ArgsListUI.py
+++ b/main_ui_files/ArgsListUI.py
@@ -109,6 +109,14 @@ class ArgsWidget(QtWidgets.QWidget):
                 dataset_args[widget.name] = widget.dataset_args
         return {"args": args, "dataset": dataset_args}
 
+    def get_validation_errors(self) -> list[str]:
+        errors: list[str] = []
+        for widget in self.args_widget_array:
+            validator = getattr(widget, "get_validation_errors", None)
+            if callable(validator):
+                errors.extend(validator())
+        return errors
+
     def load_args(self, args: dict, dataset_args: dict) -> None:
         for widget in self.args_widget_array:
             widget.load_args(args)

--- a/main_ui_files/ExtraArgsUI.py
+++ b/main_ui_files/ExtraArgsUI.py
@@ -43,12 +43,16 @@ class ExtraArgsWidget(BaseWidget):
         self.dataset_args = {}
         for arg in self.extra_args:
             name, value, is_dataset = arg.get_arg()
-            if not name or not value:
+            if not name:
                 continue
+            value_str = "" if value is None else str(value)
+            if not value_str.strip():
+                continue
+            parsed_value = self._parse_value(value_str)
             if is_dataset:
-                self.edit_dataset_args(name, value)
+                self.edit_dataset_args(name, parsed_value)
             else:
-                self.edit_args(name, value)
+                self.edit_args(name, parsed_value)
 
     def remove_extra_arg(self, widget: ExtraItem):
         self.layout().removeWidget(widget)
@@ -86,3 +90,32 @@ class ExtraArgsWidget(BaseWidget):
             self.extra_args[-1].arg_value_input.setText(str(value))
             self.extra_args[-1].is_dataset_toggle.setChecked(is_dataset)
         self.modify_extra_args()
+
+    def get_validation_errors(self) -> list[str]:
+        errors: list[str] = []
+        for arg in self.extra_args:
+            name, value, _ = arg.get_arg()
+            if not name:
+                continue
+            value_str = "" if value is None else str(value)
+            if not value_str.strip():
+                errors.append(
+                    f"Extra arg '{name}' has no value; remove it or provide a value (use 'true'/'false' for booleans) before saving TOML or training."
+                )
+        return errors
+
+    @staticmethod
+    def _parse_value(value: str) -> object:
+        stripped = value.strip()
+        lower = stripped.lower()
+        if lower == "true":
+            return True
+        if lower == "false":
+            return False
+        try:
+            return int(stripped)
+        except ValueError:
+            try:
+                return float(stripped)
+            except ValueError:
+                return stripped

--- a/main_ui_files/MainUI.py
+++ b/main_ui_files/MainUI.py
@@ -83,6 +83,13 @@ class MainWidget(QWidget):
         return base_args, subset_args
 
     def save_toml(self, file_name: Path | None = None) -> None:
+        validation_errors = self.args_widget.get_validation_errors()
+        if validation_errors:
+            message = "\n".join(validation_errors)
+            QtWidgets.QMessageBox.warning(self, "Invalid Extra Args", message)
+            print("Cannot save TOML while extra args lack values:")
+            print(message)
+            return
         args, subset_args = self.get_args()
         new_args = {arg: {"args": val} for arg, val in args["args"].items()}
         for arg, val in args["dataset"].items():
@@ -141,6 +148,13 @@ class MainWidget(QWidget):
             with contextlib.suppress(Exception):
                 requests.get(f"{self.backend_url_input.text()}/stop_training")
             self.begin_training_button.setText("Start Training")
+            return
+        validation_errors = self.args_widget.get_validation_errors()
+        if validation_errors:
+            error_text = "\n".join(validation_errors)
+            QtWidgets.QMessageBox.warning(self, "Invalid Extra Args", error_text)
+            print("Training blocked until extra args are fixed:")
+            print(error_text)
             return
         self.training_thread = Thread(target=self.start_training_thread)
         self.training_thread.start()


### PR DESCRIPTION
Some small adjustments to the bottom most Extra Args UI dropdown.  

1. When having an arg that takes a float input (eg `caption_tag_dropout_rate`) and setting the value to `0.1` or similar, it will error. This PR fixes that, and also saves the value correctly as number value to the TOML
2. If there's an arg that normally doesn't take any values in CLI such as `debug_dataset` normally you need to set `true` or `false` (case-insensitive) as arg value in the UI. One of the changes in this PR include that the UI repo now handles the `true` string to python boolean parsing which is normally handled by validation.py in the backend repo but I believe it's better if its handled here since the backend doesn't save the toml - The UI now saves bool values correctly to the toml eg `debug_dataset = true` instead of `debug_dataset = "true"`
3. When an arg name is added but the value for it is empty, originally the whole pipeline would just ignore it in a `if not name or not value: continue`; Now, a warning message box will appear when trying to press 'Start Training' button and 'File > Save Toml' while an arg name is set but no value is present.
3.1. It will also log to console about it

An extra note to the toml value type changes: I think its still backwards compatible with UI before this change since it's still loaded as string into the textboxes, booleans however will appear go from `true` in the toml to `True` in the UI, but if I'm seeing https://github.com/67372a/LoRA_Easy_Training_scripts_Backend/blob/refresh/utils/validation.py#L132C1-L136C29 correctly then this shouldn't be an issue

Trying to start training: 
<img width="1747" height="989" alt="image" src="https://github.com/user-attachments/assets/126f7252-e1f7-47fc-8be4-2b951ad3c107" />

Log message when trying to save toml (messagebox error message is the same as trying to start training):
<img width="1046" height="68" alt="image" src="https://github.com/user-attachments/assets/9ebf31f0-65bf-4bb5-9df9-da518a10d989" />

Args being saved as correct types 
<img width="387" height="94" alt="image" src="https://github.com/user-attachments/assets/c40923d9-acc5-4951-87ec-b60f73a732fe" />


This "UI saves string and backend makes it correct but is not applied correctly to toml" thing also seems to be the case for optimizer args optional args, but there doesn't seem to be an issue with values being string so it's not a breaking bug or anything though I guess it would be preferable if it would also save correct type to the toml; Either way just noting it down here so it's known for whenever 