### PR TITLE
Add Compact Mode toggle for qt-material themes

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ def main() -> None:
         
         # Add larger font size when using compact mode
         if density == "-2":
-            extra['font_size'] = '16px'
+            extra['font_size'] = '15px'
 
         apply_stylesheet(
             app,

--- a/main_ui_files/MainWindow.py
+++ b/main_ui_files/MainWindow.py
@@ -223,7 +223,7 @@ class MainWindow(QMainWindow, QtStyleTools):
             extra = {'density_scale': density_val}
             
             if is_compact:
-                extra['font_size'] = '16px'
+                extra['font_size'] = '15px'
 
             apply_stylesheet(
                 self.app,


### PR DESCRIPTION
Adds a "Compact Mode (Material)" toggle to "Themes" item in the menu bar.  
<img width="259" height="234" alt="image" src="https://github.com/user-attachments/assets/54402886-23ed-4563-b1fc-c722d462f614" />


This toggle changes the density scale of qt-material themes from the default (0) to -2 (I believe the range is +3 to -3); it also saves to the config.json to persist on restarts  
"No Theme" option is unaffected.  

Before/After:

<details>
<summary>Expand me</summary>

Launch size first pair, maximized second pair 

<img width="1056" height="957" alt="image" src="https://github.com/user-attachments/assets/41bf291a-d6b2-4ebe-bab8-87fe0a4a708e" />

<img width="1077" height="963" alt="image" src="https://github.com/user-attachments/assets/7e5f57e8-7592-4acb-aaae-f748898cb804" />


Maximized

<img width="1792" height="965" alt="image" src="https://github.com/user-attachments/assets/773360b6-8989-4447-9601-1b12bda92ca0" />

<img width="1792" height="962" alt="image" src="https://github.com/user-attachments/assets/cd64580b-5e93-4656-b504-2adaba2e9613" />

</details>

I also added subprocess import in MainWindow.py because apparently it was missing in MainWindow.py's closeEvent() try except block, I never encountered an issue with it myself though so I put potential error in commit message