### PR TITLE
Fix VAE batch size save value when 1

### DIFF
--- a/main_ui_files/ExperimentalArgsUI.py
+++ b/main_ui_files/ExperimentalArgsUI.py
@@ -212,8 +212,7 @@ class ExperimentalArgsUI(QWidget):
 
         # adv. vae args
         self.edit_args("vae_reflection", self.widget.vae_reflection_enable.isChecked(), True)
-        if self.widget.vae_batch_size_input.value() != 1:
-            self.edit_args("vae_batch_size", self.widget.vae_batch_size_input.value(), True)
+        self.edit_args("vae_batch_size", self.widget.vae_batch_size_input.value(), True)
         if self.widget.vae_custom_scale_enable.isChecked():
             self.edit_args("vae_custom_scale", self.widget.vae_custom_scale_input.value(), True)
         if self.widget.vae_custom_shift_enable.isChecked():
@@ -258,8 +257,7 @@ class ExperimentalArgsUI(QWidget):
 
         # adv. vae args
         self.edit_args("vae_reflection", self.widget.vae_reflection_enable.isChecked(), True)
-        if self.widget.vae_batch_size_input.value() != 1:  # no need to add if it's default value
-            self.edit_args("vae_batch_size", self.widget.vae_batch_size_input.value(), True)
+        self.edit_args("vae_batch_size", self.widget.vae_batch_size_input.value(), True)
         if self.widget.vae_custom_scale_enable.isChecked() and self.widget.vae_custom_scale_enable.isEnabled():
             self.edit_args("vae_custom_scale", self.widget.vae_custom_scale_input.value(), True)
         else:


### PR DESCRIPTION
Removes logic that prevents saving of vae batch size arg when it's set to 1 because it caused the issue below  

If user loaded a TOML with VAE batch size higher than 1, e.g.: 4  
Then setting the value to anything other than 4 that is not 1 (like 2, 3, 8, etc), it will work fine  
However: should the value in the UI be set to 1, it would fallback to whatever value was in the last loaded TOML (in this case 4) instead of not saving the arg at all which is what I had originally in mind to save space in the TOML