### PR TITLE
Add multi-GPU training support via accelerate launch

### DIFF
--- a/main_ui_files/AccelerateUI.py
+++ b/main_ui_files/AccelerateUI.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+from PySide6.QtWidgets import QWidget
+from ui_files.AccelerateUI import Ui_accelerate_ui
+from modules.BaseWidget import BaseWidget
+
+
+class AccelerateWidget(BaseWidget):
+    """Widget for configuring multi-GPU training with accelerate launch.
+
+    Unlike other widgets, this one saves settings to config.json instead of
+    using self.args, because accelerate settings are machine-specific and
+    should not be saved to training TOML files.
+    """
+
+    def __init__(self, parent: QWidget = None) -> None:
+        super().__init__(parent)
+        self.colap.set_title("Multi-GPU Training (Accelerate)")
+        self.widget = Ui_accelerate_ui()
+
+        # Use a unique name but we won't use self.args for training config
+        self.name = "accelerate_args"
+        self.args = {}  # Keep empty - accelerate settings go to config.json
+        self.dataset_args = {}
+
+        self.setup_widget()
+        self.setup_connections()
+        self.load_from_config()
+
+    def setup_widget(self) -> None:
+        super().setup_widget()
+        self.widget.setupUi(self.content)
+
+    def setup_connections(self) -> None:
+        # Save to config.json whenever any setting changes
+        self.widget.accelerate_group.clicked.connect(self.save_to_config)
+        self.widget.num_processes_input.valueChanged.connect(self.save_to_config)
+        self.widget.main_process_port_input.valueChanged.connect(self.save_to_config)
+
+    def get_accelerate_settings(self) -> dict:
+        """Return accelerate settings for passing to backend."""
+        if not self.widget.accelerate_group.isChecked():
+            return {"enabled": False}
+
+        return {
+            "enabled": True,
+            "num_processes": self.widget.num_processes_input.value(),
+            "main_process_port": self.widget.main_process_port_input.value(),
+        }
+
+    def save_to_config(self) -> None:
+        """Persist accelerate settings to config.json."""
+        config_path = Path("config.json")
+        config_dict = json.loads(config_path.read_text()) if config_path.exists() else {}
+        config_dict["accelerate"] = self.get_accelerate_settings()
+        config_path.write_text(json.dumps(config_dict, indent=2))
+
+    def load_from_config(self) -> None:
+        """Load accelerate settings from config.json."""
+        config_path = Path("config.json")
+        if not config_path.exists():
+            return
+
+        config_dict = json.loads(config_path.read_text())
+        accel = config_dict.get("accelerate", {})
+
+        self.widget.accelerate_group.setChecked(accel.get("enabled", False))
+        self.widget.num_processes_input.setValue(accel.get("num_processes", 2))
+        self.widget.main_process_port_input.setValue(accel.get("main_process_port", 29500))
+
+    def load_args(self, args: dict) -> bool:
+        """Load accelerate settings from config.json (not from TOML args)."""
+        self.load_from_config()
+        return True
+
+    def load_dataset_args(self, dataset_args: dict) -> bool:
+        """No dataset args for accelerate settings."""
+        return True

--- a/main_ui_files/ArgsListUI.py
+++ b/main_ui_files/ArgsListUI.py
@@ -1,5 +1,6 @@
 from PySide6.QtCore import Signal
 from PySide6 import QtWidgets, QtCore
+from main_ui_files.AccelerateUI import AccelerateWidget
 from main_ui_files.FluxUI import FluxWidget
 from main_ui_files.AnimaUI import AnimaWidget
 
@@ -144,6 +145,8 @@ class ArgsWidget(QtWidgets.QWidget):
         self.flux_widget.Toggled.connect(lambda _: refresh_anima_disabled_state())
 
         self.args_widget_array.append(EDMLossWidget())
+        self.accelerate_widget = AccelerateWidget()
+        self.args_widget_array.append(self.accelerate_widget)
         self.args_widget_array.append(ExtraArgsWidget())
 
         for widget in self.args_widget_array:

--- a/main_ui_files/MainUI.py
+++ b/main_ui_files/MainUI.py
@@ -191,8 +191,14 @@ class MainWidget(QWidget):
 
     def train_helper(self, url: str, train_toml: Path) -> bool:
         args, dataset_args, train_mode = self.process_toml(train_toml)
-        final_args = {"args": args, "dataset": dataset_args}
         config = json.loads(Path("config.json").read_text())
+
+        # Include accelerate settings in validation request for proper warmup step calculation
+        final_args = {
+            "args": args,
+            "dataset": dataset_args,
+            "accelerate": config.get("accelerate", {}),
+        }
         try:
             response = requests.post(f"{url}/validate", json=True, data=json.dumps(final_args))
         except ConnectionError as e:
@@ -225,15 +231,23 @@ class MainWidget(QWidget):
         is_sdxl = str(args.get("general_args").get("sdxl", False))
         is_flux = str(bool(args.get("flux_args")))
         is_anima = str(bool(args.get("anima_args")))
-        response = requests.get(
-            f"{url}/train",
-            params={
-                "train_mode": train_mode.value,
-                "sdxl": is_sdxl,
-                "flux": is_flux,
-                "anima": is_anima,
-            },
-        )
+
+        # Build train params including accelerate settings
+        train_params = {
+            "train_mode": train_mode.value,
+            "sdxl": is_sdxl,
+            "flux": is_flux,
+            "anima": is_anima,
+        }
+
+        # Add accelerate settings if enabled
+        accel = config.get("accelerate", {})
+        if accel.get("enabled", False):
+            train_params["accelerate_enabled"] = "True"
+            train_params["accelerate_num_processes"] = str(accel.get("num_processes", 2))
+            train_params["accelerate_main_process_port"] = str(accel.get("main_process_port", 29500))
+
+        response = requests.get(f"{url}/train", params=train_params)
         training = True
         while training:
             sleep(5.0)

--- a/ui_files/AccelerateUI.py
+++ b/ui_files/AccelerateUI.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Custom UI file for Accelerate (Multi-GPU) settings
+##
+## Created for: LoRA Easy Training Scripts
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QMetaObject, Qt)
+from PySide6.QtWidgets import (QCheckBox, QFormLayout, QGroupBox, QLabel,
+    QSizePolicy, QVBoxLayout, QWidget)
+
+from modules.ScrollOnSelect import SpinBox
+
+
+class Ui_accelerate_ui(object):
+    def setupUi(self, accelerate_ui):
+        if not accelerate_ui.objectName():
+            accelerate_ui.setObjectName(u"accelerate_ui")
+        accelerate_ui.resize(400, 120)
+
+        self.verticalLayout = QVBoxLayout(accelerate_ui)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.verticalLayout.setContentsMargins(0, 0, 0, 0)
+
+        # Main group box (checkable to enable/disable multi-GPU)
+        self.accelerate_group = QGroupBox(accelerate_ui)
+        self.accelerate_group.setObjectName(u"accelerate_group")
+        self.accelerate_group.setCheckable(True)
+        self.accelerate_group.setChecked(False)
+
+        self.formLayout = QFormLayout(self.accelerate_group)
+        self.formLayout.setObjectName(u"formLayout")
+
+        # Number of GPUs
+        self.num_processes_label = QLabel(self.accelerate_group)
+        self.num_processes_label.setObjectName(u"num_processes_label")
+        self.formLayout.setWidget(0, QFormLayout.LabelRole, self.num_processes_label)
+
+        self.num_processes_input = SpinBox(self.accelerate_group)
+        self.num_processes_input.setObjectName(u"num_processes_input")
+        self.num_processes_input.setFocusPolicy(Qt.StrongFocus)
+        self.num_processes_input.setMinimum(1)
+        self.num_processes_input.setMaximum(16)
+        self.num_processes_input.setValue(2)
+        self.formLayout.setWidget(0, QFormLayout.FieldRole, self.num_processes_input)
+
+        # Main Process Port
+        self.main_process_port_label = QLabel(self.accelerate_group)
+        self.main_process_port_label.setObjectName(u"main_process_port_label")
+        self.formLayout.setWidget(1, QFormLayout.LabelRole, self.main_process_port_label)
+
+        self.main_process_port_input = SpinBox(self.accelerate_group)
+        self.main_process_port_input.setObjectName(u"main_process_port_input")
+        self.main_process_port_input.setFocusPolicy(Qt.StrongFocus)
+        self.main_process_port_input.setMinimum(1024)
+        self.main_process_port_input.setMaximum(65535)
+        self.main_process_port_input.setValue(29500)
+        self.formLayout.setWidget(1, QFormLayout.FieldRole, self.main_process_port_input)
+
+        self.verticalLayout.addWidget(self.accelerate_group)
+
+        self.retranslateUi(accelerate_ui)
+        QMetaObject.connectSlotsByName(accelerate_ui)
+    # setupUi
+
+    def retranslateUi(self, accelerate_ui):
+        accelerate_ui.setWindowTitle(QCoreApplication.translate("accelerate_ui", u"Form", None))
+        self.accelerate_group.setTitle(QCoreApplication.translate("accelerate_ui", u"Enable Multi-GPU Training", None))
+        self.accelerate_group.setToolTip(QCoreApplication.translate("accelerate_ui",
+            u"<html><head/><body><p>Enable multi-GPU training using accelerate launch, your GPUs must be the same. "
+            u"This will distribute the training across multiple GPUs. Please configure your accelerate first. Number of GPUs equals --num_processes=X</p></body></html>", None))
+        self.num_processes_label.setText(QCoreApplication.translate("accelerate_ui", u"Number of GPUs", None))
+        self.num_processes_label.setToolTip(QCoreApplication.translate("accelerate_ui",
+            u"<html><head/><body><p>Number of GPUs to use for distributed training.</p></body></html>", None))
+        self.main_process_port_label.setText(QCoreApplication.translate("accelerate_ui", u"Main Process Port", None))
+        self.main_process_port_label.setToolTip(QCoreApplication.translate("accelerate_ui",
+            u"<html><head/><body><p>Port for the main process to communicate with other processes. "
+            u"Change this if the default port (29500) is already in use.</p></body></html>", None))
+    # retranslateUi


### PR DESCRIPTION
Adds a new Accelerate UI section for configuring distributed multi-GPU training:
- New AccelerateWidget with enable toggle, GPU count, and port settings
- Settings persist to config.json (machine-specific, not saved to training TOML)
- Frontend passes accelerate params to backend for launch command and step calculation
- Backend submodule updated with accelerate launch support


Quality of life for rare folks like me that have multiple-gpus :doro:

<img width="724" height="184" alt="imagen" src="https://github.com/user-attachments/assets/0251bdb4-c674-49f1-aad4-c1952161907e" />

Looks like that, assumes user already configured Accelerate for multi-gpu, if no multi-gpu is enabled, it will run in default mode.

Hovering whill show the following message:

<img width="222" height="148" alt="imagen" src="https://github.com/user-attachments/assets/1e1b4568-5a80-425b-9e12-7d4f24462e0e" />
