### PR TITLE
Fix RAWR and CAWR showing incorrectly in metadata

### DIFF
--- a/main_ui_files/OptimizerUI.py
+++ b/main_ui_files/OptimizerUI.py
@@ -211,7 +211,6 @@ class OptimizerWidget(BaseWidget):
                 True,
             )
             self.edit_lr_args("gamma", 1 - self.widget.gamma_input.value(), True)
-            return
         elif value in {"rex_annealing_warm_restarts_(RAWR)", "rex"}:
             self.widget.cosine_restart_input.setEnabled(True)
             self.widget.min_lr_input.setEnabled(True)
@@ -229,7 +228,6 @@ class OptimizerWidget(BaseWidget):
             )
             self.edit_lr_args("gamma", 1 - self.widget.gamma_input.value(), True)
             self.edit_lr_args("d", self.widget.d_param_input.value(), True)
-            return
         elif value == "polynomial":
             self.widget.poly_power_input.setEnabled(True)
             self.edit_args("lr_scheduler_power", self.widget.poly_power_input.value(), True)


### PR DESCRIPTION
Currently, when using tools like [LoRA Metadata Viewer](https://xypher7.github.io/lora-metadata-viewer/) to read the metadata of LoRAs trained with the RAWR (rex) or CAWR schedulers, the metadata incorrectly displays the scheduler that was selected before switching to RAWR/CAWR as scheduler. This happens because the `lr_scheduler` parameter is not updated correctly.
This PR fixes that issue.

### RAWR before & after:
<img width="721" height="207" alt="Screenshot (161)" src="https://github.com/user-attachments/assets/0651825e-8e13-4a86-b18d-39a7fa3f8d40" />

### CAWR before & after:
<img width="767" height="194" alt="Screenshot (163)" src="https://github.com/user-attachments/assets/4d21903f-90d7-4dba-9563-5c843662638c" />

#### The backend will still continue to use the correct scheduler:

##### RAWR

<img width="1784" height="29" alt="Screenshot (159)" src="https://github.com/user-attachments/assets/d3a98646-f788-4739-968e-ea9d4d0e4250" />

##### CAWR
<img width="1753" height="28" alt="Screenshot (160)" src="https://github.com/user-attachments/assets/195f9b93-ba5b-44a2-8a56-8ce2a3736387" />
