### PR TITLE
Fix incorrect UI default values on launch

### DIFF
--- a/ui_files/NetworkUI.py
+++ b/ui_files/NetworkUI.py
@@ -317,7 +317,7 @@ class Ui_network_ui(object):
         self.network_dim_input.setFocusPolicy(Qt.StrongFocus)
         self.network_dim_input.setMinimum(1)
         self.network_dim_input.setMaximum(16777215)
-        self.network_dim_input.setValue(16)
+        self.network_dim_input.setValue(32)
 
         self.formLayout.setWidget(0, QFormLayout.FieldRole, self.network_dim_input)
 
@@ -332,7 +332,7 @@ class Ui_network_ui(object):
         self.network_alpha_input.setFocusPolicy(Qt.StrongFocus)
         self.network_alpha_input.setDecimals(2)
         self.network_alpha_input.setMaximum(16777215.000000000000000)
-        self.network_alpha_input.setValue(32.000000000000000)
+        self.network_alpha_input.setValue(16.000000000000000)
 
         self.formLayout.setWidget(1, QFormLayout.FieldRole, self.network_alpha_input)
 

--- a/ui_files/OptimizerUI.py
+++ b/ui_files/OptimizerUI.py
@@ -223,6 +223,7 @@ class Ui_optimizer_ui(object):
         self.optimizer_type_selector.addItem(QCoreApplication.translate("optimizer_ui", u"WiwiOpt", None))
         self.optimizer_type_selector.setObjectName(u"optimizer_type_selector")
         self.optimizer_type_selector.setFocusPolicy(Qt.StrongFocus)
+        self.optimizer_type_selector.setCurrentText("AdamW")
 
         self.formLayout.setWidget(0, QFormLayout.FieldRole, self.optimizer_type_selector)
 


### PR DESCRIPTION
Fixes a visual bug where the UI displays incorrect default values upon launch.

The UI shows network_dim = 16, network_alpha = 32, optimizer_type = ABMOG (the first item in the optimizer type list):

<img width="242" height="85" alt="image" src="https://github.com/user-attachments/assets/c5b2a27a-fbe3-4e9f-8c1d-d6be009138f6" />

<img width="217" height="35" alt="image" src="https://github.com/user-attachments/assets/37f4765e-3741-4992-9206-e65f13d051eb" />

#

But the actual values sent to the backend and the config file are set to network_dim = 32, network_alpha = 16, optimizer_type = AdamW:

```json
{
  "args": {
    "general_args": {
      "seed": 42,
      "clip_skip": 2,
      "max_train_epochs": 1,
      "max_data_loader_n_workers": 1,
      "persistent_data_loader_workers": true,
      "max_token_length": 225,
      "prior_loss_weight": 1,
      "mixed_precision": "fp16",
      "vae_batch_size": 1
    },
    "network_args": {
      "network_dim": 32,
      "network_alpha": 16,
      "min_timestep": 0,
      "max_timestep": 1000
    },
    "textual_inversion_args": {
      "token_string": "",
      "init_word": ""
    },
    "optimizer_args": {
      "optimizer_type": "AdamW",
      "lr_scheduler": "cosine",
      "learning_rate": 0.0001,
      "max_grad_norm": 1,
      "loss_type": "l2",
      "optimizer_args": {
        "weight_decay": "0.1"
      }
    },
    "saving_args": {
      "save_precision": "fp16",
      "save_model_as": "safetensors"
    },
    "logging_args": {
      "log_prefix_mode": "disabled",
      "run_name_mode": "default"
    },
    "edm_loss_args": {
      "edm2_loss_weighting": false
    }
  },
  "dataset": {
    "subsets": [
      {
        "num_repeats": 1,
        "caption_extension": ".txt",
        "name": "subset 1"
      }
    ],
    "general_args": {
      "resolution": 1024,
      "batch_size": 1
    },
    "bucket_args": {
      "enable_bucket": true,
      "min_bucket_reso": 256,
      "max_bucket_reso": 3072,
      "bucket_reso_steps": 64
    }
  },
  "accelerate": {}
}
```