### PR TITLE
Fix toml loading

### DIFF
--- a/main_ui_files/NetworkUI.py
+++ b/main_ui_files/NetworkUI.py
@@ -133,7 +133,7 @@ class NetworkWidget(BaseWidget):
         )
         self.widget.lora_fa_enable.clicked.connect(lambda x: self.edit_args("fa", x, True))
         self.widget.add_network_arg_button.clicked.connect(self.add_network_arg)
-        
+
         self.widget.train_blocks_selector.currentTextChanged.connect(
             lambda x: self.edit_network_args("train_blocks", x.lower())
         )
@@ -596,6 +596,10 @@ class NetworkWidget(BaseWidget):
             "down_lr_weight",
             "mid_lr_weight",
             "up_lr_weight",
+            "block_dims",
+            "block_alphas",
+            "conv_block_dims",
+            "conv_block_alphas",
         ]
         for _ in range(len(self.network_args)):
             self.remove_network_arg(self.network_args[0])


### PR DESCRIPTION
Currently, if a toml file contains `block_dims`, `block_alphas`, `conv_block_dims`, or `conv_block_alphas` in `[network_args]`, the ui will only load args for the general and network widget, and won't load args for other widgets.

These args are already read by `main_ui_files.NetworkUI.load_block_weights()`, but are not skipped by `load_network_args()`. Since these args have type `list` and the ui tries to load them as strings, `main_ui_files.ArgsWidget.load_args()` crashes.

```
Traceback (most recent call last):
  File "D:\lora\LoRA_Easy_Training_Scripts\main_ui_files\MainUI.py", line 124, in load_toml
    self.args_widget.load_args(args, dataset_args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "D:\lora\LoRA_Easy_Training_Scripts\main_ui_files\ArgsListUI.py", line 216, in load_args
    widget.load_args(args)
    ~~~~~~~~~~~~~~~~^^^^^^
  File "D:\lora\LoRA_Easy_Training_Scripts\main_ui_files\NetworkUI.py", line 551, in load_args
    self.load_network_args(network_args)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "D:\lora\LoRA_Easy_Training_Scripts\main_ui_files\NetworkUI.py", line 606, in load_network_args
    self.add_network_arg(arg, value)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "D:\lora\LoRA_Easy_Training_Scripts\main_ui_files\NetworkUI.py", line 158, in add_network_arg
    self.network_args.append(OptimizerItem(arg_name=arg_name, arg_value=arg_value))
                             ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\lora\LoRA_Easy_Training_Scripts\modules\OptimizerItem.py", line 28, in __init__
    self.arg_value_input.setText(self.arg_value or "")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'PySide6.QtWidgets.QLineEdit.setText' called with wrong argument types:
  PySide6.QtWidgets.QLineEdit.setText(list)
Supported signatures:
  PySide6.QtWidgets.QLineEdit.setText(arg__1: str | None, /)
```